### PR TITLE
fix: adjusting the default branch on deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow, changing the deployment branch from `master` to `main` in the `.github/workflows/deploy.yml` file.